### PR TITLE
Run dist/index.js as action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,4 +6,4 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: "node24"
-  main: "index.js"
+  main: "dist/index.js"


### PR DESCRIPTION
I realize that the action isn't actually using the intended `dist/index.js` so this addresses that.

Still works as intended: https://github.com/tekktrik/Adafruit_CircuitPython_BME680/pull/3